### PR TITLE
Openbox/x11vncの実行ユーザ指定方法変更

### DIFF
--- a/docker/vnc/Dockerfile
+++ b/docker/vnc/Dockerfile
@@ -81,7 +81,9 @@ RUN echo "NO_AT_BRIDGE=1" >> /home/developer/.bashrc
 
 # 必要なファイルのコピー
 COPY vnc/rootfs /
-RUN chown developer -R /home/developer
+RUN chown developer:developer -R /home/developer
+RUN chown developer:developer /entrypoint_vnc.sh \
+    && chmod +x /entrypoint_vnc.sh
 
 ENTRYPOINT ["/entrypoint_vnc.sh"]
 

--- a/docker/vnc/rootfs/entrypoint_vnc.sh
+++ b/docker/vnc/rootfs/entrypoint_vnc.sh
@@ -3,9 +3,12 @@
 DEVELOPER_NAME=developer
 DEV_HOME=/home/${DEVELOPER_NAME}
 
+# ユーザーの指定
+sed -i -e "s|{{USER}}|${DEVELOPER_NAME}|" -e "s|{{HOME}}|${DEV_HOME}|" /etc/supervisor/conf.d/supervisord.conf
+
 # x11vncへの追加引数
 if [ -n "$X11VNC_ARGS" ]; then
-    sed -i "s/^command=gosu {{USER}} x11vnc.*/& ${X11VNC_ARGS}/" /etc/supervisor/conf.d/supervisord.conf
+    sed -i "s/^command=x11vnc.*/& ${X11VNC_ARGS}/" /etc/supervisor/conf.d/supervisord.conf
 fi
 
 # VNCパスワード設定
@@ -14,7 +17,7 @@ if [ -n "$PASSWORD" ]; then
     echo -n "$PASSWORD" > ${DEV_HOME}/.x11vnc/password1
     x11vnc -storepasswd $(cat ${DEV_HOME}/.x11vnc/password1) ${DEV_HOME}/.x11vnc/password2
     chmod 400 ${DEV_HOME}/.x11vnc/password*
-    sed -i "s!command=gosu {{USER}} x11vnc.*!& -rfbauth ${DEV_HOME}/.x11vnc/password2!" /etc/supervisor/conf.d/supervisord.conf
+    sed -i "s!command=x11vnc.*!& -rfbauth ${DEV_HOME}/.x11vnc/password2!" /etc/supervisor/conf.d/supervisord.conf
     export PASSWORD=
 fi
 
@@ -27,8 +30,6 @@ fi
 if [ -n "$OPENBOX_ARGS" ]; then
     sed -i "s#^command=/usr/bin/openbox\$#& ${OPENBOX_ARGS}#" /etc/supervisor/conf.d/supervisord.conf
 fi
-
-sed -i -e "s|{{USER}}|${DEVELOPER_NAME}|" -e "s|{{HOME}}|${DEV_HOME}|" /etc/supervisor/conf.d/supervisord.conf
 
 # home folder
 if [ ! -x "${DEV_HOME}/.config/pcmanfm/LXDE/" ]; then

--- a/docker/vnc/rootfs/etc/supervisor/conf.d/supervisord.conf
+++ b/docker/vnc/rootfs/etc/supervisor/conf.d/supervisord.conf
@@ -9,7 +9,8 @@ programs=xvfb,wm,lxpanel,pcmanfm,x11vnc
 
 [program:wm]
 priority=15
-command=gosu {{USER}} /usr/bin/openbox
+command=/usr/bin/openbox
+user={{USER}}
 environment=DISPLAY=":1",HOME="{{HOME}}",USER="{{USER}}"
 
 [program:ibus]
@@ -40,4 +41,5 @@ stopsignal=KILL
 
 [program:x11vnc]
 priority=20
-command=gosu {{USER}} x11vnc -display :1 -xkb -forever -shared -repeat -capslock -noxrecord
+command=x11vnc -display :1 -xkb -forever -shared -repeat -capslock -noxrecord
+user={{USER}}


### PR DESCRIPTION
Openbox/x11vncの実行ユーザーの指定方法をgosuコマンドからuserパラメータに変更致しました。

また、現状は特に問題は出ておりませんが、ホームディレクトリのグループ権限設定と、
entrypoint_vnc.shの権限設定も追加致しました。