### PR TITLE
ベースイメージの指定手段追加とsimコンテナのGitHubへのSSH接続対応

### DIFF
--- a/commands/config.sh
+++ b/commands/config.sh
@@ -2,6 +2,7 @@
 # Repository config values
 #----------------------------------------------------------
 # 使用するburger-war-kitイメージのバージョン
+KIT_IMAGE=ghcr.io/p-robotics-hub/burger-war-kit
 KIT_VERSION=latest
 
 # Dockerイメージ名(公開パッケージ名)

--- a/commands/docker-build.sh
+++ b/commands/docker-build.sh
@@ -7,6 +7,7 @@
 #+
 #-[OPTIONS]
 #-  -a options    burger-war-core/burger-war-devの'docker build'に追加で渡す引数を指定（複数回指定可能）
+#-  -b options    ベースイメージの指定 (default: ghcr.io/p-robotics-hub/burger-war-kit)
 #-  -c options    burger-war-coreの'docker build'に追加で渡す引数を指定（複数回指定可能）
 #-  -d options    burger-war-devの'docker build'に追加で渡す引数を指定（複数回指定可能）
 #-  -k version    利用するburger-war-kitのバージョンを指定
@@ -64,12 +65,15 @@ CORE_BUILD_OPTION=
 IMAGE_VERSION=latest
 BUILD_TARGET=dev
 BUILD_DOCKER_IMAGE_NAME=${DOCKER_IMAGE_PREFIX}-${BUILD_TARGET}
-while getopts a:c:d:k:t:v:h OPT
+while getopts a:b:c:d:k:t:v:h OPT
 do
   case $OPT in
     a  ) # burger-war-core/burger-war-devのdocker buildへの追加オプション引数指定
       CORE_BUILD_OPTION="${CORE_BUILD_OPTION} ${OPTARG}"
       DEV_BUILD_OPTION="${DEV_BUILD_OPTION} ${OPTARG}"
+      ;;
+    b  ) # kitのイメージリポジトリを指定してビルド
+      KIT_IMAGE="${OPTARG}"
       ;;
     c  ) # burger-war-coreのdocker buildへの追加オプション引数指定
       CORE_BUILD_OPTION="${CORE_BUILD_OPTION} ${OPTARG}"
@@ -107,7 +111,7 @@ shift $((OPTIND - 1))
 # burger-war-kitのイメージを取得
 #------------------------------------------------
 set -x
-docker pull ghcr.io/p-robotics-hub/burger-war-kit:${KIT_VERSION}
+docker pull ${KIT_IMAGE}:${KIT_VERSION}
 set +x
 
 # コアイメージ用のDockerfileのビルド
@@ -115,6 +119,7 @@ set +x
 set -x
 docker build \
   ${CORE_BUILD_OPTION} \
+  --build-arg KIT_IMAGE=${KIT_IMAGE} \
   --build-arg KIT_VERSION=${KIT_VERSION} \
   ${PROXY_OPTION} \
   -f "${CORE_DOCKER_FILE_PATH}" \

--- a/commands/docker-build.sh
+++ b/commands/docker-build.sh
@@ -3,14 +3,14 @@
 #-burger-war-core/burger-war-devのDockerfileをビルドする
 #-
 #+[USAGE]
-#+  $0 [-a BUILDオプション(core/dev)] [-c BUILDオプション(core)] [-d BUILDオプション(dev)] [-k kitイメージのバージョン] [-t BUILDターゲット][-v 作成イメージのバージョン] [-h]
+#+  $0 [-a BUILDオプション(core/dev)] [-b ベースイメージ] [-c BUILDオプション(core)] [-d BUILDオプション(dev)] [-k ベースイメージのバージョン] [-t BUILDターゲット][-v 作成イメージのバージョン] [-h]
 #+
 #-[OPTIONS]
 #-  -a options    burger-war-core/burger-war-devの'docker build'に追加で渡す引数を指定（複数回指定可能）
 #-  -b options    ベースイメージの指定 (default: ghcr.io/p-robotics-hub/burger-war-kit)
 #-  -c options    burger-war-coreの'docker build'に追加で渡す引数を指定（複数回指定可能）
 #-  -d options    burger-war-devの'docker build'に追加で渡す引数を指定（複数回指定可能）
-#-  -k version    利用するburger-war-kitのバージョンを指定
+#-  -k version    利用するベースイメージのバージョンを指定 (default: latest)
 #-  -t target     ビルドするターゲットの指定(dev|robo|sim|vnc) *coreは常にビルドされる
 #-  -v version    'docker build -t'で指定するイメージのバージョンを指定 (default: latest)
 #-  -h            このヘルプを表示

--- a/commands/docker-launch.sh
+++ b/commands/docker-launch.sh
@@ -270,6 +270,7 @@ else
   docker run \
     --name ${RUN_DOCKER_CONTAINER_NAME} \
     -d \
+    --init \
     --privileged \
     --net host \
     --mount type=bind,src=/tmp/.X11-unix/,dst=/tmp/.X11-unix \

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,5 +1,6 @@
+ARG KIT_IMAGE=ghcr.io/p-robotics-hub/burger-war-kit
 ARG KIT_VERSION=latest
-FROM ghcr.io/p-robotics-hub/burger-war-kit:$KIT_VERSION
+FROM $KIT_IMAGE:$KIT_VERSION
 
 #-------------------------------------------------------------------------------------------------
 # シミュレーション対戦環境/実機環境での実行に必要なパッケージをインストールする

--- a/docker/sim/Dockerfile
+++ b/docker/sim/Dockerfile
@@ -98,6 +98,8 @@ RUN apt-get update -q && apt-get install -y --no-install-recommends \
         xdotool \
         gstreamer1.0-tools \
         gstreamer1.0-plugins-good \
+        openssh-server \
+        connect-proxy \
     && rm -rf /var/lib/apt/lists/*
 
 #-------------------------------------------------------------------------------------------------
@@ -109,7 +111,7 @@ RUN echo "export LANG=ja_JP.UTF-8" >> /home/developer/.bashrc \
     && echo "export LC_ALL=ja_JP.UTF-8" >> /home/developer/.bashrc \
     && echo "export GTK_IM_MODULE=ibus" >> /home/developer/.bashrc \
     && echo "export QT_IM_MODULE=ibus" >> /home/developer/.bashrc \
-    && echo "export XMODIFIERS='@im=ibus'" >> /home/developer/.bashrc 
+    && echo "export XMODIFIERS='@im=ibus'" >> /home/developer/.bashrc
 
 # gnome-terminal起動時の以下の警告対策
 # Couldn't register with accessibility busµ

--- a/docker/sim/rootfs/home/developer/.ssh/config
+++ b/docker/sim/rootfs/home/developer/.ssh/config
@@ -1,0 +1,6 @@
+#Host github.com
+#    HostName ssh.github.com
+#    Port 443
+#    ProxyCommand connect -H http://10.0.1.20:7979 %h %p
+#    User  github-user-name
+#    IdentityFile ~/.ssh/id_rsa


### PR DESCRIPTION
以下の点を修正致しました。

## ①ベースイメージの指定手段追加
以下の3つ用意しております。

※1～3は優先度が高い順です。1の-bオプション指定が一番優先されます。

  1. ビルド時のコマンドで追加 (-bオプションを追加)
     例) ベースイメージにghcr.io/p-robotics-hub/burger-war-kit:testを指定する場合は以下になります
         ```bash commands/docker-build.sh -b ghcr.io/p-robotics-hub/burger-war-kit -k test```

  2. commands/config.shのKIT_IMAGE変数
    ⇒ docker-build.shでビルドする際のデフォルト値です。
       docker-build.sの-bオプション未指定時はこのファイルの定義値が使用されます。

  3. docker/core/DockerfileのARG KIT_IMAGE
    ⇒ commands/docker-build.shを使用せずにdocker buildする際のデフォルト値です。

## ②burger-war-simコンテナでGitHubにSSH接続に必要なものを追加

  - openssh-server
   ⇒ SSHキーの作成などで使用します

  - connect-proxy
   ⇒ SSHのプロキシ経由接続で使用します

  - docker/sim/root_fs/home/developer/.ssh/config
   ⇒ GitHubへのSSH接続設定のテンプレートを記載しています。
      ※ユーザーごとに変更する必要があるため、デフォルトではコメントアウトしています

## ③burger-war-devコンテナの停止の高速化
以前から気になっていた、burger-war-devコンテナの停止に時間がかかっていた挙動を解消しました。
